### PR TITLE
Adding support for mapping SAML groups

### DIFF
--- a/config/mappings.yaml.erb
+++ b/config/mappings.yaml.erb
@@ -8,3 +8,11 @@ mappings:
     <% next unless key.start_with?('SAML_MAPPINGS_') %>
     <%= key.delete_prefix('SAML_MAPPINGS_').downcase %>: "<%= ENV[key] %>"
   <% end %>
+
+groups:
+  attribute: '<%= ENV['SAML_GROUP_ATTRIBUTE'] %>'
+  mappings:
+  <% ENV.each do |key, value| %>
+    <% next unless key.start_with?('SAML_GROUP_MAPPINGS_') %>
+    "<%= ENV[key] %>": <%= key.delete_prefix('SAML_GROUP_MAPPINGS_').downcase %>
+  <% end %>

--- a/saml_proxy.rb
+++ b/saml_proxy.rb
@@ -84,7 +84,9 @@ class SamlProxy < Sinatra::Base
     session[:authed] = true
     session[:mappings] = {}
     settings.mappings.each do |attr, header|
-      session[:mappings][header] = saml_response.attributes[attr]
+      session[:mappings][header] = attr == settings.groups[:attribute] ?
+        saml_response.attributes.multi(attr).map{|group_id| settings.groups[:mappings][group_id]} :
+        saml_response.attributes[attr]
     end
   end
 end


### PR DESCRIPTION
@lyang this PR adds support for mapping a list of groups/roles in the SAML response to a list of groups/roles that the application expects. 

I was able to use this to map group IDs returned by my SAML IdP into application roles expected by my application. 