### PR TITLE
fix dockerfile + parameterized http host setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build "${APP_ROOT}" "${APP_ROOT}"
 COPY helpers ./helpers
 COPY config ./config
-COPY config.ru saml_proxy.rb LICENSE "$APP_ROOT"
+COPY config.ru saml_proxy.rb LICENSE "$APP_ROOT/"
 RUN addgroup --system --gid 1000 samlproxy && \
     adduser --system --uid 1000 samlproxy --ingroup samlproxy && \
     chown -R samlproxy:samlproxy "$APP_ROOT"

--- a/saml_proxy.rb
+++ b/saml_proxy.rb
@@ -72,7 +72,12 @@ class SamlProxy < Sinatra::Base
   private
 
   def saml_settings
-    self.class.saml_settings ||= load_saml_settings
+    temp = self.class.saml_settings ||= load_saml_settings
+    assertion_url = settings.saml[:assertion_consumer_service_url]
+    if assertion_url.include?("%HOST%")
+      temp.assertion_consumer_service_url = assertion_url.clone.sub! '%HOST%', request.env["HTTP_HOST"]
+    end
+    temp
   end
 
   def valid?(saml_response)


### PR DESCRIPTION
Greetings,

this pull request addresses 2 specific issues i encountered:

1) fix dockerfile: in my environment (ubuntu 24.04 `docker.io/noble-updates,now 26.1.3-0ubuntu1~24.04.1`) `docker build` would fail when running
`COPY config.ru saml_proxy.rb LICENSE "$APP_ROOT`
adding a final slash fixed the issue for me

2) i wanted the ability to have multiple applications each one of them with their unique FQDN all with SAML auth with a single instance of `nginx `and `saml-proxy`, i was able to do this with this patch and running `saml-proxy` with:
`SAML_ASSERTION_CONSUMER_SERVICE_URL=https://%HOST%/consume`
and finally i had to add:
`proxy_set_header Host $host;`
on `/start` and `/consume` endpoint on nginx