### PR TITLE
Add platform-specific gems to lockfile for multi-arch builds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,22 @@ GEM
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-musl)
+      racc (~> 1.4)
     overcommit (0.70.0)
       childprocess (>= 0.6.3, < 6)
       iniparse (~> 1.4)
@@ -131,7 +147,15 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   overcommit (~> 0.70.0)


### PR DESCRIPTION
## Summary
- Adds precompiled `nokogiri` native gem entries and a `PLATFORMS` list to `Gemfile.lock` via `bundle lock --add-platform`
- Covers linux (`aarch64`/`arm`/`x86_64`, both `gnu` and `musl`) and darwin (`arm64`/`x86_64`)
- Lets CI and container builds install precompiled nokogiri instead of compiling from source, speeding up and stabilizing installs across architectures
- `BUNDLED WITH` is intentionally left at `2.6.3` (a local-bundler-induced downgrade to `2.6.2` was reverted)

## Test Plan
- [ ] `bundle install` succeeds on each target platform without compiling nokogiri from source
- [ ] CI passes