### PR TITLE
Remove Ruby 3.2 from CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4', '4.0']
+        ruby-version: ['3.3', '3.4', '4.0']
 
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Drops `3.2` from the CI `ruby-version` matrix in `.github/workflows/build.yml`
- Ruby 3.2 reached end-of-life on 2025-03-31, so it no longer receives security/bug fixes
- CI continues to test the supported versions: `3.3`, `3.4`, `4.0`

## Test Plan
- [ ] CI runs the matrix across `3.3`, `3.4`, `4.0` only and passes